### PR TITLE
Add a source code hash property to task variants

### DIFF
--- a/src/__tests__/RoarTask.test.ts
+++ b/src/__tests__/RoarTask.test.ts
@@ -27,6 +27,7 @@ const taskInput = {
   variantName: 'a-test-variant-name',
   taskDescription: 'test-task-description',
   variantDescription: 'test-variant-description',
+  srcHash: 'abcdefg',
   blocks: [
     {
       blockNumber: 0,
@@ -125,6 +126,7 @@ describe('RoarTaskVariant', () => {
           description: task.variantDescription,
           blocks: task.blocks,
           blocksString: JSON.stringify(task.blocks),
+          srcHash: task.srcHash,
           lastPlayed: expect.any(Timestamp),
         }),
       );
@@ -176,6 +178,7 @@ describe('RoarTaskVariant', () => {
           description: task1.variantDescription,
           blocks: task1.blocks,
           blocksString: JSON.stringify(task1.blocks),
+          srcHash: task1.srcHash,
           lastPlayed: expect.any(Timestamp),
         }),
       );
@@ -185,6 +188,7 @@ describe('RoarTaskVariant', () => {
           description: task2.variantDescription,
           blocks: task2.blocks,
           blocksString: JSON.stringify(task2.blocks),
+          srcHash: task2.srcHash,
           lastPlayed: expect.any(Timestamp),
         }),
       );

--- a/src/firestore/task.ts
+++ b/src/firestore/task.ts
@@ -28,6 +28,7 @@ export interface TaskVariantInput {
   taskDescription?: string | null;
   variantDescription?: string | null;
   blocks?: Block[];
+  srcHash?: string | null;
 }
 
 interface FirestoreTaskData {
@@ -56,6 +57,7 @@ export class RoarTaskVariant {
   variantRef: DocumentReference | undefined;
   variantsCollectionRef: CollectionReference | undefined;
   blocks: Block[];
+  srcHash: string | null;
   constructor({
     taskId,
     taskName,
@@ -63,6 +65,7 @@ export class RoarTaskVariant {
     taskDescription = null,
     variantDescription = null,
     blocks = [],
+    srcHash = null,
   }: TaskVariantInput) {
     this.taskId = taskId;
     this.taskName = taskName;
@@ -70,6 +73,7 @@ export class RoarTaskVariant {
     this.variantName = variantName;
     this.variantDescription = variantDescription;
     this.blocks = blocks;
+    this.srcHash = srcHash;
 
     this.taskRef = undefined;
     this.variantsCollectionRef = undefined;
@@ -126,11 +130,12 @@ export class RoarTaskVariant {
       });
 
       // Check to see if variant exists already by querying for a match on the
-      // name and the blocks.
+      // name, srcHash, and the blocks.
       const q = query(
         this.variantsCollectionRef,
         where('name', '==', this.variantName),
         where('blocksString', '==', JSON.stringify(this.blocks)),
+        where('srcHash', '==', this.srcHash),
         orderBy('lastPlayed', 'desc'),
         limit(1),
       );
@@ -158,6 +163,7 @@ export class RoarTaskVariant {
           description: this.variantDescription,
           blocks: this.blocks,
           blocksString: JSON.stringify(this.blocks),
+          srcHash: this.srcHash,
           lastPlayed: serverTimestamp(),
         };
         this.variantRef = doc(this.variantsCollectionRef);


### PR DESCRIPTION
This PR adds a `srcHash` property to the task variant documents on Firestore. Previously, the user had to differentiate task variants by specifying the block structure explicitly. This was cumbersome and not all assessment fit this block structure. Now, the user can still specify the block structure if they want, but they can also leave it blank and provide a unique hash for their variant's source code. Furthermore, I'm adding some code to the `create-roar-app` initializer that will automatically create a hash of the `src` directory and use that for the variant's `srcHash` property.